### PR TITLE
Switch `try!` macro to 1.13's `?` operator

### DIFF
--- a/src/cell/mod.rs
+++ b/src/cell/mod.rs
@@ -131,7 +131,7 @@ impl<'a, T: 'a + store::Store> RateLimiter<'a, T> {
 
             // tat refers to the theoretical arrival time that would be expected
             // from equally spaced requests at exactly the rate limit.
-            let (tat_val, now) = try!(self.store.get_with_time(key));
+            let (tat_val, now) = self.store.get_with_time(key)?;
 
             let tat = match tat_val {
                 -1 => now,
@@ -180,11 +180,11 @@ impl<'a, T: 'a + store::Store> RateLimiter<'a, T> {
             // Both of these cases are designed to work around the fact that
             // another limiter could be running in parallel.
             let updated = if tat_val == -1 {
-                try!(self.store
-                    .set_if_not_exists_with_ttl(key, new_tat_ns, ttl))
+                self.store
+                    .set_if_not_exists_with_ttl(key, new_tat_ns, ttl)?
             } else {
-                try!(self.store
-                    .compare_and_swap_with_ttl(key, tat_val, new_tat_ns, ttl))
+                self.store
+                    .compare_and_swap_with_ttl(key, tat_val, new_tat_ns, ttl)?
             };
 
             if updated {
@@ -466,7 +466,7 @@ mod tests {
         }
 
         fn get_with_time(&self, key: &str) -> Result<(i64, time::Tm), CellError> {
-            let tup = try!(self.store.get_with_time(key));
+            let tup = self.store.get_with_time(key)?;
             Ok((tup.0, self.clock))
         }
 

--- a/src/cell/store.rs
+++ b/src/cell/store.rs
@@ -132,16 +132,16 @@ impl<'a> Store for InternalRedisStore<'a> {
                                  new: i64,
                                  ttl: time::Duration)
                                  -> Result<bool, CellError> {
-        let val = try!(self.r.coerce_integer(self.r.get(key)));
+        let val = self.r.coerce_integer(self.r.get(key))?;
         match val {
             redis::Reply::Nil => Ok(false),
 
             // Still the old value: perform the swap.
             redis::Reply::Integer(n) if n == old => {
                 if ttl.num_seconds() > 1 {
-                    try!(self.r.setex(key, ttl.num_seconds(), new.to_string().as_str()));
+                    self.r.setex(key, ttl.num_seconds(), new.to_string().as_str())?;
                 } else {
-                    try!(self.r.set(key, new.to_string().as_str()));
+                    self.r.set(key, new.to_string().as_str())?;
                 }
 
                 Ok(true)
@@ -158,7 +158,7 @@ impl<'a> Store for InternalRedisStore<'a> {
     fn get_with_time(&self, key: &str) -> Result<(i64, time::Tm), CellError> {
         // TODO: currently leveraging that CommandError and CellError are the
         // same thing, but we should probably reconcile this.
-        let val = try!(self.r.coerce_integer(self.r.get(key)));
+        let val = self.r.coerce_integer(self.r.get(key))?;
         match val {
             redis::Reply::Nil => Ok((-1, time::now_utc())),
             redis::Reply::Integer(n) => Ok((n, time::now_utc())),
@@ -175,9 +175,9 @@ impl<'a> Store for InternalRedisStore<'a> {
                                   value: i64,
                                   ttl: time::Duration)
                                   -> Result<bool, CellError> {
-        let val = try!(self.r.setnx(key, value.to_string().as_str()));
+        let val = self.r.setnx(key, value.to_string().as_str())?;
         if ttl.num_seconds() > 1 {
-            try!(self.r.expire(key, ttl.num_seconds()));
+            self.r.expire(key, ttl.num_seconds())?;
         }
         Ok(val)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,11 +37,11 @@ impl Command for ThrottleCommand {
 
         // the first argument is command name "cl.throttle" (ignore it)
         let key = args[1];
-        let max_burst = try!(parse_i64(args[2]));
-        let count = try!(parse_i64(args[3]));
-        let period = try!(parse_i64(args[4]));
+        let max_burst = parse_i64(args[2])?;
+        let count = parse_i64(args[3])?;
+        let period = parse_i64(args[4])?;
         let quantity = match args.get(5) {
-            Some(n) => try!(parse_i64(n)),
+            Some(n) => parse_i64(n)?,
             None => 1,
         };
 
@@ -56,18 +56,18 @@ impl Command for ThrottleCommand {
                                                      max_rate: rate,
                                                  });
 
-        let (throttled, rate_limit_result) = try!(limiter.rate_limit(key, quantity));
+        let (throttled, rate_limit_result) = limiter.rate_limit(key, quantity)?;
 
         // Reply with an array containing rate limiting results. Note that
         // Redis' support for interesting data types is quite weak, so we have
         // to jam a few square pegs into round holes. It's a little messy, but
         // the interface comes out as pretty workable.
-        try!(r.reply_array(5));
-        try!(r.reply_integer(if throttled { 1 } else { 0 }));
-        try!(r.reply_integer(rate_limit_result.limit));
-        try!(r.reply_integer(rate_limit_result.remaining));
-        try!(r.reply_integer(rate_limit_result.retry_after.num_seconds()));
-        try!(r.reply_integer(rate_limit_result.reset_after.num_seconds()));
+        r.reply_array(5)?;
+        r.reply_integer(if throttled { 1 } else { 0 })?;
+        r.reply_integer(rate_limit_result.limit)?;
+        r.reply_integer(rate_limit_result.remaining)?;
+        r.reply_integer(rate_limit_result.retry_after.num_seconds())?;
+        r.reply_integer(rate_limit_result.reset_after.num_seconds())?;
 
         Ok(())
     }

--- a/src/redis/mod.rs
+++ b/src/redis/mod.rs
@@ -154,7 +154,7 @@ impl Redis {
     }
 
     pub fn expire(&self, key: &str, ttl: i64) -> Result<bool, CellError> {
-        let res = try!(self.call("EXPIRE", &[key, ttl.to_string().as_str()]));
+        let res = self.call("EXPIRE", &[key, ttl.to_string().as_str()])?;
         parse_bool(res)
     }
 
@@ -199,17 +199,17 @@ impl Redis {
     }
 
     pub fn set(&self, key: &str, val: &str) -> Result<(), CellError> {
-        let res = try!(self.call("SET", &[key, val]));
+        let res = self.call("SET", &[key, val])?;
         parse_simple_string(res)
     }
 
     pub fn setex(&self, key: &str, ttl: i64, val: &str) -> Result<(), CellError> {
-        let res = try!(self.call("SETEX", &[key, ttl.to_string().as_str(), val]));
+        let res = self.call("SETEX", &[key, ttl.to_string().as_str(), val])?;
         parse_simple_string(res)
     }
 
     pub fn setnx(&self, key: &str, val: &str) -> Result<bool, CellError> {
-        let res = try!(self.call("SETNX", &[key, val]));
+        let res = self.call("SETNX", &[key, val])?;
         parse_bool(res)
     }
 }
@@ -269,7 +269,7 @@ fn parse_args(argv: *mut *mut raw::RedisModuleString,
     let mut args: Vec<String> = Vec::with_capacity(argc as usize);
     for i in 0..argc {
         let redis_str = unsafe { *argv.offset(i as isize) };
-        args.push(try!(manifest_redis_string(redis_str)));
+        args.push(manifest_redis_string(redis_str)?);
     }
     Ok(args)
 }


### PR DESCRIPTION
Moves `try!` to the newly released, and more visually pleasing, `?`
operator.