### PR TITLE
Use low level Redis module APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ build = "build.rs"
 crate-type = ["dylib"]
 
 [dependencies]
+bitflags = "0.7.0"
 libc = "0.2.0"
 time = "0.1"
 

--- a/src/cell/store.rs
+++ b/src/cell/store.rs
@@ -132,7 +132,7 @@ impl<'a> Store for InternalRedisStore<'a> {
                                  new: i64,
                                  ttl: time::Duration)
                                  -> Result<bool, CellError> {
-        let key = self.r.open_key(key, redis::KeyMode::ReadWrite);
+        let key = self.r.open_key_writable(key);
         match key.read()? {
             Some(s) => {
                 if s.parse::<i64>()? == old {
@@ -155,7 +155,7 @@ impl<'a> Store for InternalRedisStore<'a> {
     fn get_with_time(&self, key: &str) -> Result<(i64, time::Tm), CellError> {
         // TODO: currently leveraging that CommandError and CellError are the
         // same thing, but we should probably reconcile this.
-        let key = self.r.open_key(key, redis::KeyMode::Read);
+        let key = self.r.open_key(key);
         match key.read()? {
             Some(s) => {
                 let n = s.parse::<i64>()?;
@@ -174,7 +174,7 @@ impl<'a> Store for InternalRedisStore<'a> {
                                   value: i64,
                                   ttl: time::Duration)
                                   -> Result<bool, CellError> {
-        let key = self.r.open_key(key, redis::KeyMode::ReadWrite);
+        let key = self.r.open_key_writable(key);
         let res = if key.is_empty()? {
             key.write(value.to_string().as_str())?;
             Ok(true)

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,16 +1,23 @@
+use std;
 use std::error;
 use std::fmt;
-use std::string;
 
 #[derive(Debug)]
 pub enum CellError {
     Generic(GenericError),
-    String(string::FromUtf8Error),
+    String(std::string::FromUtf8Error),
+    ParseIntError(std::num::ParseIntError),
 }
 
 impl CellError {
     pub fn generic(message: &str) -> CellError {
         CellError::Generic(GenericError::new(message))
+    }
+}
+
+impl From<std::num::ParseIntError> for CellError {
+    fn from(err: std::num::ParseIntError) -> CellError {
+        CellError::ParseIntError(err)
     }
 }
 
@@ -21,6 +28,7 @@ impl fmt::Display for CellError {
             // their implementations.
             CellError::Generic(ref err) => write!(f, "{}", err),
             CellError::String(ref err) => write!(f, "{}", err),
+            CellError::ParseIntError(ref err) => write!(f, "{}", err),
         }
     }
 }
@@ -32,6 +40,7 @@ impl error::Error for CellError {
         match *self {
             CellError::Generic(ref err) => err.description(),
             CellError::String(ref err) => err.description(),
+            CellError::ParseIntError(ref err) => err.description(),
         }
     }
 
@@ -43,6 +52,7 @@ impl error::Error for CellError {
             // implement `Error`.
             CellError::Generic(ref err) => Some(err),
             CellError::String(ref err) => Some(err),
+            CellError::ParseIntError(ref err) => Some(err),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#[macro_use]
+extern crate bitflags;
 extern crate libc;
 extern crate time;
 

--- a/src/redis/mod.rs
+++ b/src/redis/mod.rs
@@ -218,6 +218,8 @@ pub struct RedisKey {
     key_str: *mut raw::RedisModuleString,
 }
 
+/// RedisKey is an abstraction over a Redis key that allows readonly
+/// operations.
 impl RedisKey {
     fn open(ctx: *mut raw::RedisModuleCtx, key: &str) -> RedisKey {
         let key_str = raw::create_string(ctx, format!("{}\0", key).as_ptr(), key.len());
@@ -253,6 +255,8 @@ impl Drop for RedisKey {
     }
 }
 
+/// RedisKey is an abstraction over a Redis key that allows read and write
+/// operations.
 pub struct RedisKeyWritable {
     ctx: *mut raw::RedisModuleCtx,
     key_inner: *mut raw::RedisModuleKey,

--- a/src/redis/raw.rs
+++ b/src/redis/raw.rs
@@ -8,15 +8,13 @@ use libc::{c_int, c_long, c_longlong, size_t};
 // There's a ~0 chance that any of these will ever change so it's pretty safe.
 pub const REDISMODULE_APIVER_1: c_int = 1;
 
-#[derive(Debug)]
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum KeyMode {
     Read = (1 << 0),
     Write = (1 << 1),
 }
 
-#[derive(Debug)]
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum ReplyType {
     Unknown = -1,
     String = 0,
@@ -26,8 +24,7 @@ pub enum ReplyType {
     Nil = 4,
 }
 
-#[derive(Debug)]
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum Status {
     Ok = 0,
     Err = 1,
@@ -150,6 +147,13 @@ pub fn reply_with_string(ctx: *mut RedisModuleCtx,
     unsafe { RedisModule_ReplyWithString(ctx, str) }
 }
 
+// Sets the expiry on a key.
+//
+// Expire is in milliseconds.
+pub fn set_expire(key: *mut RedisModuleKey, expire: c_longlong) -> Status {
+    unsafe { RedisModule_SetExpire(key, expire) }
+}
+
 pub fn string_dma(key: *mut RedisModuleKey,
                   len: *mut size_t,
                   mode: KeyMode)
@@ -233,6 +237,11 @@ extern "C" {
     static RedisModule_ReplyWithString: extern "C" fn(ctx: *mut RedisModuleCtx,
                                                       str: *mut RedisModuleString)
                                                       -> Status;
+
+    static RedisModule_SetExpire: extern "C" fn(key: *mut RedisModuleKey,
+                                                expire: c_longlong)
+                                                -> Status;
+
 
     static RedisModule_StringDMA: extern "C" fn(key: *mut RedisModuleKey,
                                                 len: *mut size_t,

--- a/src/redis/raw.rs
+++ b/src/redis/raw.rs
@@ -150,6 +150,13 @@ pub fn reply_with_string(ctx: *mut RedisModuleCtx,
     unsafe { RedisModule_ReplyWithString(ctx, str) }
 }
 
+pub fn string_dma(key: *mut RedisModuleKey,
+                  len: *mut size_t,
+                  mode: KeyMode)
+                  -> *const u8 {
+    unsafe { RedisModule_StringDMA(key, len, mode) }
+}
+
 pub fn string_ptr_len(str: *mut RedisModuleString, len: *mut size_t) -> *const u8 {
     unsafe { RedisModule_StringPtrLen(str, len) }
 }
@@ -226,6 +233,11 @@ extern "C" {
     static RedisModule_ReplyWithString: extern "C" fn(ctx: *mut RedisModuleCtx,
                                                       str: *mut RedisModuleString)
                                                       -> Status;
+
+    static RedisModule_StringDMA: extern "C" fn(key: *mut RedisModuleKey,
+                                                len: *mut size_t,
+                                                mode: KeyMode)
+                                                -> *const u8;
 
     static RedisModule_StringPtrLen: extern "C" fn(str: *mut RedisModuleString,
                                                    len: *mut size_t)

--- a/src/redis/raw.rs
+++ b/src/redis/raw.rs
@@ -8,10 +8,11 @@ use libc::{c_int, c_long, c_longlong, size_t};
 // There's a ~0 chance that any of these will ever change so it's pretty safe.
 pub const REDISMODULE_APIVER_1: c_int = 1;
 
-#[derive(Debug, PartialEq)]
-pub enum KeyMode {
-    Read = (1 << 0),
-    Write = (1 << 1),
+bitflags! {
+    pub flags KeyMode: c_int {
+        const KEYMODE_READ = (1 << 0),
+        const KEYMODE_WRITE = (1 << 1),
+    }
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
Switch to use low level Redis module APIs (i.e. off of the more blunt `CALL`
API). Theoretically this should result in improved performance (but in practice
doesn't seem to make a huge difference),