### PR TITLE
stick with one version of gcc, fix linking of redismodule

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ libc = "0.2.0"
 time = "0.1"
 
 [build-dependencies]
-gcc = "*"
+gcc = "0.3"

--- a/src/redis/raw.rs
+++ b/src/redis/raw.rs
@@ -176,7 +176,7 @@ pub fn string_set(key: *mut RedisModuleKey, str: *mut RedisModuleString) -> Stat
 // we do is bake redismodule.h's symbols into a library of our construction
 // during build and link against that. See build.rs for details.
 #[allow(improper_ctypes)]
-#[link(name = "redismodule")]
+#[link(name="redismodule", kind="static")]
 extern "C" {
     pub fn Export_RedisModule_Init(ctx: *mut RedisModuleCtx,
                                    modulename: *const u8,
@@ -278,7 +278,6 @@ pub mod call1 {
     }
 
     #[allow(improper_ctypes)]
-    #[link(name = "redismodule")]
     extern "C" {
         pub static RedisModule_Call: extern "C" fn(ctx: *mut raw::RedisModuleCtx,
                                                    cmdname: *const u8,
@@ -301,7 +300,6 @@ pub mod call2 {
     }
 
     #[allow(improper_ctypes)]
-    #[link(name = "redismodule")]
     extern "C" {
         pub static RedisModule_Call: extern "C" fn(ctx: *mut raw::RedisModuleCtx,
                                                    cmdname: *const u8,
@@ -326,7 +324,6 @@ pub mod call3 {
     }
 
     #[allow(improper_ctypes)]
-    #[link(name = "redismodule")]
     extern "C" {
         pub static RedisModule_Call: extern "C" fn(ctx: *mut raw::RedisModuleCtx,
                                                    cmdname: *const u8,


### PR DESCRIPTION
Fixing this:  

```
[dwerner:~/Development/redis-cell]$ cargo build                                                                                                                                                                                                          (master✱) 
   Compiling redis-cell v0.1.0 (file:///home/dwerner/Development/redis-cell)
error: linking with `cc` failed: exit code: 1
  |
  = note: "cc" "-Wl,--as-needed" "-Wl,-z,noexecstack" "-m64" "-L" "/home/dwerner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib" "/home/dwerner/Development/redis-cell/target/debug/deps/redis_cell.0.o" "-o" "/home/dwerner/Development/redis-cell/target/debug/deps/libredis_cell.so" "/home/dwerner/Development/redis-cell/target/debug/deps/redis_cell.metadata.o" "-nodefaultlibs" "-L" "/home/dwerner/Development/redis-cell/target/debug/deps" "-L" "/home/dwerner/Development/redis-cell/target/debug/build/redis-cell-e6aa6e97cadb4225/out" "-L" "/home/dwerner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-Wl,-Bstatic" "-Wl,--whole-archive" "-l" "redismodule" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "-l" "redismodule" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "-l" "redismodule" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "-l" "redismodule" "-Wl,--no-whole-archive" "-Wl,-Bdynamic" "-Wl,--whole-archive" "/tmp/rustc.hv1RaTTFmLaL/libbitflags-65ddff5d2b91509e.rlib" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "/tmp/rustc.hv1RaTTFmLaL/libtime-cd5e3a346d1a17b6.rlib" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "/tmp/rustc.hv1RaTTFmLaL/liblibc-5dc7b85e748840b4.rlib" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "/tmp/rustc.hv1RaTTFmLaL/libstd-13f36e2630c2d79b.rlib" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "/tmp/rustc.hv1RaTTFmLaL/libpanic_unwind-3b9d178f1de89528.rlib" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "/tmp/rustc.hv1RaTTFmLaL/libunwind-93bb403c9fc56f72.rlib" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "/tmp/rustc.hv1RaTTFmLaL/librand-a2ef7979b4b3e1d5.rlib" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "/tmp/rustc.hv1RaTTFmLaL/libcollections-d22754c8c52de3a1.rlib" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "/tmp/rustc.hv1RaTTFmLaL/liballoc-c53f99154bf815c4.rlib" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "/tmp/rustc.hv1RaTTFmLaL/liballoc_system-17a71bb92a82956c.rlib" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "/tmp/rustc.hv1RaTTFmLaL/liblibc-739908a2e215dd88.rlib" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "/tmp/rustc.hv1RaTTFmLaL/libstd_unicode-1cc5fcd37568ebc4.rlib" "-Wl,--no-whole-archive" "-Wl,--whole-archive" "/tmp/rustc.hv1RaTTFmLaL/libcore-3f4289353c600297.rlib" "-Wl,--no-whole-archive" "/tmp/rustc.hv1RaTTFmLaL/libcompiler_builtins-07bfb3bcb2a51da0.rlib" "-l" "util" "-l" "dl" "-l" "rt" "-l" "pthread" "-l" "gcc_s" "-l" "pthread" "-l" "c" "-l" "m" "-l" "rt" "-l" "util" "-shared"
  = note: /home/dwerner/Development/redis-cell/target/debug/build/redis-cell-e6aa6e97cadb4225/out/libredismodule.a(redismodule.o): In function `Export_RedisModule_Init':
          /home/dwerner/Development/redis-cell/src/redismodule.c:6: multiple definition of `Export_RedisModule_Init'
          /home/dwerner/Development/redis-cell/target/debug/build/redis-cell-e6aa6e97cadb4225/out/libredismodule.a(redismodule.o):/home/dwerner/Development/redis-cell/src/redismodule.c:6: first defined here
          /home/dwerner/Development/redis-cell/target/debug/build/redis-cell-e6aa6e97cadb4225/out/libredismodule.a(redismodule.o): In function `Export_RedisModule_Init':
          /home/dwerner/Development/redis-cell/src/redismodule.c:6: multiple definition of `Export_RedisModule_Init'
          /home/dwerner/Development/redis-cell/target/debug/build/redis-cell-e6aa6e97cadb4225/out/libredismodule.a(redismodule.o):redismodule.c:(.text.Export_RedisModule_Init+0x0): first defined here
          /home/dwerner/Development/redis-cell/target/debug/build/redis-cell-e6aa6e97cadb4225/out/libredismodule.a(redismodule.o): In function `Export_RedisModule_Init':
          /home/dwerner/Development/redis-cell/src/redismodule.c:6: multiple definition of `Export_RedisModule_Init'
          /home/dwerner/Development/redis-cell/target/debug/build/redis-cell-e6aa6e97cadb4225/out/libredismodule.a(redismodule.o):redismodule.c:(.text.Export_RedisModule_Init+0x0): first defined here
          collect2: error: ld returned 1 exit status
          

```
