### PR TITLE
Correctly check whether the time is in the past

### DIFF
--- a/src/cell/mod.rs
+++ b/src/cell/mod.rs
@@ -152,7 +152,7 @@ impl<'a, T: 'a + store::Store> RateLimiter<'a, T> {
                        "diff = {}ms (now - allow_at)",
                        diff.num_milliseconds());
 
-            if diff.num_seconds() < 0 {
+            if diff < time::Duration::zero() {
                 log_debug!(self.store,
                            "BLOCKED retry_after = {}ms",
                            -diff.num_milliseconds());


### PR DESCRIPTION
Previous code checked if the time was less than 1 second in the future, which produces incorrect results when the period between allowed requests is < 1 second (rate > 1/s).

Closes https://github.com/brandur/redis-cell/issues/12