### PR TITLE
Check for emptyness of writable string before parsing

### DIFF
--- a/src/cell/store.rs
+++ b/src/cell/store.rs
@@ -135,7 +135,7 @@ impl<'a> Store for InternalRedisStore<'a> {
         let key = self.r.open_key_writable(key);
         match key.read()? {
             Some(s) => {
-                if s.parse::<i64>()? == old {
+                if !s.is_empty() && s.parse::<i64>()? == old {
                     // Still the old value: perform the swap.
                     key.write(new.to_string().as_str())?;
                     key.set_expire(ttl)?;


### PR DESCRIPTION
Fixes https://github.com/brandur/redis-cell/issues/11

The rationale for this check is already explained in existing code: https://github.com/brandur/redis-cell/blob/master/src/redis/mod.rs#L299-L304

As I'm not familiar to the code, I decided to modify it at the user side, but maybe a better solution might be to modify `RedisKeyWritable.read()` to return `None` for empty strings. What do you think @brandur?