### PR TITLE
Modernize Rustfmt conventions and rewrite everything

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ env:
     - CRATE_NAME=redis-cell
 
 matrix:
-  allow_failures:
-    - rust: nightly
-
   include:
     # Stable.
     - env: TARGET=x86_64-unknown-linux-gnu
@@ -29,9 +26,13 @@ matrix:
     - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
 
     # Testing other channels
-    - env: TARGET=x86_64-unknown-linux-gnu
+    - env:
+        - NIGHTLY=true
+        - TARGET=x86_64-unknown-linux-gnu
       rust: nightly
-    - env: TARGET=x86_64-apple-darwin
+    - env:
+        - NIGHTLY=true
+        - TARGET=x86_64-apple-darwin
       os: osx
       rust: nightly
 
@@ -41,13 +42,16 @@ install:
   - bash ci/install.sh
   - source ~/.cargo/env || true
 
-before_script: 
-  # Don't fail on failure to install because it's probably because the target
-  # already exists.
-  - (cargo install rustfmt || true)
+before_script:
+  - rustup component add rustfmt-preview
 
 script:
   - bash ci/script.sh
+
+  # Rustfmt is finally available as a preview component outside of nightly, but
+  # unfortunately we're using a few configuration options that are considered
+  # unstable so it still only works on nightly.
+  - if [[ $NIGHTLY == 'true' ]]; then cargo +nightly fmt --all -- --write-mode=diff; fi
 
 after_script: set +e
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+# Use this file purely for shortcuts only
+
+all: test fmt
+
+fmt:
+	cargo +nightly fmt -- --write-mode=diff
+
+test:
+	cargo test
+	cargo test -- --ignored --test-threads=1

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,7 @@
-ideal_width = 79
 max_width = 90
-#struct_lit_style = "Visual"
-write_mode = "Overwrite"
+reorder_imports = true
+reorder_imports_in_group = true
+reorder_imported_names = true
+struct_field_align_threshold = 20
+unstable_features = true
+wrap_comments = true

--- a/src/error.rs
+++ b/src/error.rs
@@ -70,7 +70,9 @@ pub struct GenericError {
 
 impl GenericError {
     pub fn new(message: &str) -> GenericError {
-        GenericError { message: String::from(message) }
+        GenericError {
+            message: String::from(message),
+        }
     }
 }
 

--- a/src/redis/raw.rs
+++ b/src/redis/raw.rs
@@ -49,19 +49,20 @@ pub struct RedisModuleKey;
 #[repr(C)]
 pub struct RedisModuleString;
 
-pub type RedisModuleCmdFunc = extern "C" fn(ctx: *mut RedisModuleCtx,
-                                            argv: *mut *mut RedisModuleString,
-                                            argc: c_int)
-                                            -> Status;
+pub type RedisModuleCmdFunc = extern "C" fn(
+    ctx: *mut RedisModuleCtx,
+    argv: *mut *mut RedisModuleString,
+    argc: c_int,
+) -> Status;
 
-pub fn init(ctx: *mut RedisModuleCtx,
-            modulename: *const u8,
-            module_version: c_int,
-            api_version: c_int)
-            -> Status {
+pub fn init(
+    ctx: *mut RedisModuleCtx,
+    modulename: *const u8,
+    module_version: c_int,
+    api_version: c_int,
+) -> Status {
     unsafe { Export_RedisModule_Init(ctx, modulename, module_version, api_version) }
 }
-
 
 pub fn call_reply_type(reply: *mut RedisModuleCallReply) -> ReplyType {
     unsafe { RedisModule_CallReplyType(reply) }
@@ -77,9 +78,10 @@ pub fn call_reply_integer(reply: *mut RedisModuleCallReply) -> c_longlong {
     unsafe { RedisModule_CallReplyInteger(reply) }
 }
 
-pub fn call_reply_string_ptr(str: *mut RedisModuleCallReply,
-                             len: *mut size_t)
-                             -> *const u8 {
+pub fn call_reply_string_ptr(
+    str: *mut RedisModuleCallReply,
+    len: *mut size_t,
+) -> *const u8 {
     unsafe { RedisModule_CallReplyStringPtr(str, len) }
 }
 
@@ -87,29 +89,33 @@ pub fn close_key(kp: *mut RedisModuleKey) {
     unsafe { RedisModule_CloseKey(kp) }
 }
 
-pub fn create_command(ctx: *mut RedisModuleCtx,
-                      name: *const u8,
-                      cmdfunc: Option<RedisModuleCmdFunc>,
-                      strflags: *const u8,
-                      firstkey: c_int,
-                      lastkey: c_int,
-                      keystep: c_int)
-                      -> Status {
+pub fn create_command(
+    ctx: *mut RedisModuleCtx,
+    name: *const u8,
+    cmdfunc: Option<RedisModuleCmdFunc>,
+    strflags: *const u8,
+    firstkey: c_int,
+    lastkey: c_int,
+    keystep: c_int,
+) -> Status {
     unsafe {
-        RedisModule_CreateCommand(ctx,
-                                  name,
-                                  cmdfunc,
-                                  strflags,
-                                  firstkey,
-                                  lastkey,
-                                  keystep)
+        RedisModule_CreateCommand(
+            ctx,
+            name,
+            cmdfunc,
+            strflags,
+            firstkey,
+            lastkey,
+            keystep,
+        )
     }
 }
 
-pub fn create_string(ctx: *mut RedisModuleCtx,
-                     ptr: *const u8,
-                     len: size_t)
-                     -> *mut RedisModuleString {
+pub fn create_string(
+    ctx: *mut RedisModuleCtx,
+    ptr: *const u8,
+    len: size_t,
+) -> *mut RedisModuleString {
     unsafe { RedisModule_CreateString(ctx, ptr, len) }
 }
 
@@ -125,10 +131,11 @@ pub fn log(ctx: *mut RedisModuleCtx, level: *const u8, fmt: *const u8) {
     unsafe { RedisModule_Log(ctx, level, fmt) }
 }
 
-pub fn open_key(ctx: *mut RedisModuleCtx,
-                keyname: *mut RedisModuleString,
-                mode: KeyMode)
-                -> *mut RedisModuleKey {
+pub fn open_key(
+    ctx: *mut RedisModuleCtx,
+    keyname: *mut RedisModuleString,
+    mode: KeyMode,
+) -> *mut RedisModuleKey {
     unsafe { RedisModule_OpenKey(ctx, keyname, mode) }
 }
 
@@ -144,9 +151,10 @@ pub fn reply_with_long_long(ctx: *mut RedisModuleCtx, ll: c_longlong) -> Status 
     unsafe { RedisModule_ReplyWithLongLong(ctx, ll) }
 }
 
-pub fn reply_with_string(ctx: *mut RedisModuleCtx,
-                         str: *mut RedisModuleString)
-                         -> Status {
+pub fn reply_with_string(
+    ctx: *mut RedisModuleCtx,
+    str: *mut RedisModuleString,
+) -> Status {
     unsafe { RedisModule_ReplyWithString(ctx, str) }
 }
 
@@ -157,10 +165,11 @@ pub fn set_expire(key: *mut RedisModuleKey, expire: c_longlong) -> Status {
     unsafe { RedisModule_SetExpire(key, expire) }
 }
 
-pub fn string_dma(key: *mut RedisModuleKey,
-                  len: *mut size_t,
-                  mode: KeyMode)
-                  -> *const u8 {
+pub fn string_dma(
+    key: *mut RedisModuleKey,
+    len: *mut size_t,
+    mode: KeyMode,
+) -> *const u8 {
     unsafe { RedisModule_StringDMA(key, len, mode) }
 }
 
@@ -176,161 +185,165 @@ pub fn string_set(key: *mut RedisModuleKey, str: *mut RedisModuleString) -> Stat
 // we do is bake redismodule.h's symbols into a library of our construction
 // during build and link against that. See build.rs for details.
 #[allow(improper_ctypes)]
-#[link(name="redismodule", kind="static")]
+#[link(name = "redismodule", kind = "static")]
 extern "C" {
-    pub fn Export_RedisModule_Init(ctx: *mut RedisModuleCtx,
-                                   modulename: *const u8,
-                                   module_version: c_int,
-                                   api_version: c_int)
-                                   -> Status;
+    pub fn Export_RedisModule_Init(
+        ctx: *mut RedisModuleCtx,
+        modulename: *const u8,
+        module_version: c_int,
+        api_version: c_int,
+    ) -> Status;
 
-    static RedisModule_CallReplyType: extern "C" fn(reply: *mut RedisModuleCallReply)
-                                                    -> ReplyType;
+    static RedisModule_CallReplyType:
+        extern "C" fn(reply: *mut RedisModuleCallReply) -> ReplyType;
 
     static RedisModule_FreeCallReply: extern "C" fn(reply: *mut RedisModuleCallReply);
 
-    static RedisModule_CallReplyInteger: extern "C" fn(reply: *mut RedisModuleCallReply)
-                                                       -> c_longlong;
+    static RedisModule_CallReplyInteger:
+        extern "C" fn(reply: *mut RedisModuleCallReply) -> c_longlong;
 
-    static RedisModule_CallReplyStringPtr: extern "C" fn(str: *mut RedisModuleCallReply,
-                                                         len: *mut size_t)
-                                                         -> *const u8;
+    static RedisModule_CallReplyStringPtr:
+        extern "C" fn(str: *mut RedisModuleCallReply, len: *mut size_t) -> *const u8;
 
     static RedisModule_CloseKey: extern "C" fn(kp: *mut RedisModuleKey);
 
-    static RedisModule_CreateCommand: extern "C" fn(ctx: *mut RedisModuleCtx,
-                                                    name: *const u8,
-                                                    cmdfunc: Option<RedisModuleCmdFunc>,
-                                                    strflags: *const u8,
-                                                    firstkey: c_int,
-                                                    lastkey: c_int,
-                                                    keystep: c_int)
-                                                    -> Status;
+    static RedisModule_CreateCommand:
+        extern "C" fn(
+        ctx: *mut RedisModuleCtx,
+        name: *const u8,
+        cmdfunc: Option<RedisModuleCmdFunc>,
+        strflags: *const u8,
+        firstkey: c_int,
+        lastkey: c_int,
+        keystep: c_int,
+    ) -> Status;
 
-    static RedisModule_CreateString: extern "C" fn(ctx: *mut RedisModuleCtx,
-                                                   ptr: *const u8,
-                                                   len: size_t)
-                                                   -> *mut RedisModuleString;
+    static RedisModule_CreateString:
+        extern "C" fn(ctx: *mut RedisModuleCtx, ptr: *const u8, len: size_t)
+        -> *mut RedisModuleString;
 
-    static RedisModule_FreeString: extern "C" fn(ctx: *mut RedisModuleCtx,
-                                                 str: *mut RedisModuleString);
+    static RedisModule_FreeString:
+        extern "C" fn(ctx: *mut RedisModuleCtx, str: *mut RedisModuleString);
 
     static RedisModule_GetSelectedDb: extern "C" fn(ctx: *mut RedisModuleCtx) -> c_int;
 
-    static RedisModule_Log: extern "C" fn(ctx: *mut RedisModuleCtx,
-                                          level: *const u8,
-                                          fmt: *const u8);
+    static RedisModule_Log:
+        extern "C" fn(ctx: *mut RedisModuleCtx, level: *const u8, fmt: *const u8);
 
-    static RedisModule_OpenKey: extern "C" fn(ctx: *mut RedisModuleCtx,
-                                              keyname: *mut RedisModuleString,
-                                              mode: KeyMode)
-                                              -> *mut RedisModuleKey;
+    static RedisModule_OpenKey:
+        extern "C" fn(
+        ctx: *mut RedisModuleCtx,
+        keyname: *mut RedisModuleString,
+        mode: KeyMode,
+    ) -> *mut RedisModuleKey;
 
-    static RedisModule_ReplyWithArray: extern "C" fn(ctx: *mut RedisModuleCtx,
-                                                     len: c_long)
-                                                     -> Status;
+    static RedisModule_ReplyWithArray:
+        extern "C" fn(ctx: *mut RedisModuleCtx, len: c_long) -> Status;
 
-    static RedisModule_ReplyWithError: extern "C" fn(ctx: *mut RedisModuleCtx,
-                                                     err: *const u8);
+    static RedisModule_ReplyWithError:
+        extern "C" fn(ctx: *mut RedisModuleCtx, err: *const u8);
 
-    static RedisModule_ReplyWithLongLong: extern "C" fn(ctx: *mut RedisModuleCtx,
-                                                        ll: c_longlong)
-                                                        -> Status;
+    static RedisModule_ReplyWithLongLong:
+        extern "C" fn(ctx: *mut RedisModuleCtx, ll: c_longlong) -> Status;
 
-    static RedisModule_ReplyWithString: extern "C" fn(ctx: *mut RedisModuleCtx,
-                                                      str: *mut RedisModuleString)
-                                                      -> Status;
+    static RedisModule_ReplyWithString:
+        extern "C" fn(ctx: *mut RedisModuleCtx, str: *mut RedisModuleString) -> Status;
 
-    static RedisModule_SetExpire: extern "C" fn(key: *mut RedisModuleKey,
-                                                expire: c_longlong)
-                                                -> Status;
+    static RedisModule_SetExpire:
+        extern "C" fn(key: *mut RedisModuleKey, expire: c_longlong) -> Status;
 
+    static RedisModule_StringDMA:
+        extern "C" fn(key: *mut RedisModuleKey, len: *mut size_t, mode: KeyMode) -> *const u8;
 
-    static RedisModule_StringDMA: extern "C" fn(key: *mut RedisModuleKey,
-                                                len: *mut size_t,
-                                                mode: KeyMode)
-                                                -> *const u8;
+    static RedisModule_StringPtrLen:
+        extern "C" fn(str: *mut RedisModuleString, len: *mut size_t) -> *const u8;
 
-    static RedisModule_StringPtrLen: extern "C" fn(str: *mut RedisModuleString,
-                                                   len: *mut size_t)
-                                                   -> *const u8;
+    static RedisModule_StringSet:
+        extern "C" fn(key: *mut RedisModuleKey, str: *mut RedisModuleString) -> Status;
 
-    static RedisModule_StringSet: extern "C" fn(key: *mut RedisModuleKey,
-                                                str: *mut RedisModuleString)
-                                                -> Status;
-
-    static RedisModule_Call: extern "C" fn(ctx: *mut RedisModuleCtx,
-                                           cmdname: *const u8,
-                                           fmt: *const u8,
-                                           args: *const *mut RedisModuleString)
-                                           -> *mut RedisModuleCallReply;
+    static RedisModule_Call:
+        extern "C" fn(
+        ctx: *mut RedisModuleCtx,
+        cmdname: *const u8,
+        fmt: *const u8,
+        args: *const *mut RedisModuleString,
+    ) -> *mut RedisModuleCallReply;
 }
 
 pub mod call1 {
     use redis::raw;
 
-    pub fn call(ctx: *mut raw::RedisModuleCtx,
-                cmdname: *const u8,
-                fmt: *const u8,
-                arg0: *mut raw::RedisModuleString)
-                -> *mut raw::RedisModuleCallReply {
+    pub fn call(
+        ctx: *mut raw::RedisModuleCtx,
+        cmdname: *const u8,
+        fmt: *const u8,
+        arg0: *mut raw::RedisModuleString,
+    ) -> *mut raw::RedisModuleCallReply {
         unsafe { RedisModule_Call(ctx, cmdname, fmt, arg0) }
     }
 
     #[allow(improper_ctypes)]
     extern "C" {
-        pub static RedisModule_Call: extern "C" fn(ctx: *mut raw::RedisModuleCtx,
-                                                   cmdname: *const u8,
-                                                   fmt: *const u8,
-                                                   arg0: *mut raw::RedisModuleString)
-                                                   -> *mut raw::RedisModuleCallReply;
+        pub static RedisModule_Call:
+            extern "C" fn(
+            ctx: *mut raw::RedisModuleCtx,
+            cmdname: *const u8,
+            fmt: *const u8,
+            arg0: *mut raw::RedisModuleString,
+        ) -> *mut raw::RedisModuleCallReply;
     }
 }
 
 pub mod call2 {
     use redis::raw;
 
-    pub fn call(ctx: *mut raw::RedisModuleCtx,
-                cmdname: *const u8,
-                fmt: *const u8,
-                arg0: *mut raw::RedisModuleString,
-                arg1: *mut raw::RedisModuleString)
-                -> *mut raw::RedisModuleCallReply {
+    pub fn call(
+        ctx: *mut raw::RedisModuleCtx,
+        cmdname: *const u8,
+        fmt: *const u8,
+        arg0: *mut raw::RedisModuleString,
+        arg1: *mut raw::RedisModuleString,
+    ) -> *mut raw::RedisModuleCallReply {
         unsafe { RedisModule_Call(ctx, cmdname, fmt, arg0, arg1) }
     }
 
     #[allow(improper_ctypes)]
     extern "C" {
-        pub static RedisModule_Call: extern "C" fn(ctx: *mut raw::RedisModuleCtx,
-                                                   cmdname: *const u8,
-                                                   fmt: *const u8,
-                                                   arg0: *mut raw::RedisModuleString,
-                                                   arg1: *mut raw::RedisModuleString)
-                                                   -> *mut raw::RedisModuleCallReply;
+        pub static RedisModule_Call:
+            extern "C" fn(
+            ctx: *mut raw::RedisModuleCtx,
+            cmdname: *const u8,
+            fmt: *const u8,
+            arg0: *mut raw::RedisModuleString,
+            arg1: *mut raw::RedisModuleString,
+        ) -> *mut raw::RedisModuleCallReply;
     }
 }
 
 pub mod call3 {
     use redis::raw;
 
-    pub fn call(ctx: *mut raw::RedisModuleCtx,
-                cmdname: *const u8,
-                fmt: *const u8,
-                arg0: *mut raw::RedisModuleString,
-                arg1: *mut raw::RedisModuleString,
-                arg2: *mut raw::RedisModuleString)
-                -> *mut raw::RedisModuleCallReply {
+    pub fn call(
+        ctx: *mut raw::RedisModuleCtx,
+        cmdname: *const u8,
+        fmt: *const u8,
+        arg0: *mut raw::RedisModuleString,
+        arg1: *mut raw::RedisModuleString,
+        arg2: *mut raw::RedisModuleString,
+    ) -> *mut raw::RedisModuleCallReply {
         unsafe { RedisModule_Call(ctx, cmdname, fmt, arg0, arg1, arg2) }
     }
 
     #[allow(improper_ctypes)]
     extern "C" {
-        pub static RedisModule_Call: extern "C" fn(ctx: *mut raw::RedisModuleCtx,
-                                                   cmdname: *const u8,
-                                                   fmt: *const u8,
-                                                   arg0: *mut raw::RedisModuleString,
-                                                   arg1: *mut raw::RedisModuleString,
-                                                   arg2: *mut raw::RedisModuleString)
-                                                   -> *mut raw::RedisModuleCallReply;
+        pub static RedisModule_Call:
+            extern "C" fn(
+            ctx: *mut raw::RedisModuleCtx,
+            cmdname: *const u8,
+            fmt: *const u8,
+            arg0: *mut raw::RedisModuleString,
+            arg1: *mut raw::RedisModuleString,
+            arg2: *mut raw::RedisModuleString,
+        ) -> *mut raw::RedisModuleCallReply;
     }
 }


### PR DESCRIPTION
Runs a modern version of Rustfmt on the project (the one available via
the `rustup-preview` toolchain in `rustup`) and rewrites a large
majority of the code. This has the nice effect of making everything
quite a bit nicer because it seems that better conventions have won out
in the end.

We also:

* Add a check in CI to make sure new code has been properly fmt'ed.
* Port a few configuration options over from another one of my projects.
  They're benign, and make things a little better.
* Adds a `Makefile` with an `all` target that will conveniently perform
  every important check that will happen in CI.

Fixes #15.