### PR TITLE
Upgrade `bitflags` package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 crate-type = ["dylib"]
 
 [dependencies]
-bitflags = "0.7.0"
+bitflags = "1.0"
 libc = "0.2.0"
 time = "0.1"
 

--- a/src/redis/mod.rs
+++ b/src/redis/mod.rs
@@ -1,5 +1,8 @@
-// This should not be public in the long run. Build an abstraction interface
+// `raw` should not be public in the long run. Build an abstraction interface
 // instead.
+//
+// We have to disable a couple Clippy checks here because we'll otherwise have
+// warnings thrown from within macros provided by the `bigflags` package.
 #[cfg_attr(feature = "cargo-clippy",
            allow(redundant_field_names, suspicious_arithmetic_impl))]
 pub mod raw;
@@ -442,12 +445,15 @@ fn from_byte_string(
 
 fn read_key(key: *mut raw::RedisModuleKey) -> Result<String, string::FromUtf8Error> {
     let mut length: size_t = 0;
-    from_byte_string(raw::string_dma(key, &mut length, raw::KEYMODE_READ), length)
+    from_byte_string(
+        raw::string_dma(key, &mut length, raw::KeyMode::READ),
+        length,
+    )
 }
 
 fn to_raw_mode(mode: KeyMode) -> raw::KeyMode {
     match mode {
-        KeyMode::Read => raw::KEYMODE_READ,
-        KeyMode::ReadWrite => raw::KEYMODE_READ | raw::KEYMODE_WRITE,
+        KeyMode::Read => raw::KeyMode::READ,
+        KeyMode::ReadWrite => raw::KeyMode::READ | raw::KeyMode::WRITE,
     }
 }

--- a/src/redis/raw.rs
+++ b/src/redis/raw.rs
@@ -11,9 +11,9 @@ use libc::{c_int, c_long, c_longlong, size_t};
 pub const REDISMODULE_APIVER_1: c_int = 1;
 
 bitflags! {
-    pub flags KeyMode: c_int {
-        const KEYMODE_READ = 1,
-        const KEYMODE_WRITE = (1 << 1),
+    pub struct KeyMode: c_int {
+        const READ = 1;
+        const WRITE = (1 << 1);
     }
 }
 


### PR DESCRIPTION
Upgrades the `bitflags` package. This comes with some nice ergonomic
improvements in that individual values are now accessible from within a
struct instead of as package-level constants.