### PR TITLE
Rustfmt and Clippy are now available on the stable channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,20 +43,17 @@ install:
   - source ~/.cargo/env || true
 
 before_script:
-  - if [[ $NIGHTLY == 'true' ]]; then rustup component add rustfmt-preview; fi
-  - if [[ $NIGHTLY == 'true' ]]; then cargo +nightly install clippy --force; fi
+  - rustup component add rustfmt
+  - rustup component add clippy
 
 script:
   - bash ci/script.sh
 
-  # Rustfmt is finally available as a preview component outside of nightly, but
-  # unfortunately we're using a few configuration options that are considered
-  # unstable so it still only works on nightly.
-  - if [[ $NIGHTLY == 'true' ]]; then cargo +nightly fmt --all -- --write-mode=diff; fi
+  # So close to being on stable, but using a few unstable options in
+  # `rustfmt.toml` (e.g. `wrap_comments` which is *still* not stable!).
+  - if [[ $NIGHTLY == 'true' ]]; then cargo fmt --all -- --check; fi
 
-  # The `-D warnings` argument means that Clippy will send a non-zero exit code
-  # if it encounters any linting problems (thus failing the build).
-  - if [[ $NIGHTLY == 'true' ]]; then cargo +nightly clippy -- -D warnings; fi
+  - cargo clippy -- -D warnings
 
 after_script: set +e
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,7 +1,5 @@
 max_width = 90
 reorder_imports = true
-reorder_imports_in_group = true
-reorder_imported_names = true
 struct_field_align_threshold = 20
 unstable_features = true
 wrap_comments = true

--- a/src/cell/mod.rs
+++ b/src/cell/mod.rs
@@ -334,7 +334,7 @@ mod tests {
 
     // Skip rustfmt so we don't mangle our big test case array below which is
     // already hard enough to read.
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     #[test]
     fn it_rate_limits() {
         let limit = 5;
@@ -403,7 +403,7 @@ mod tests {
 
             println!("limited = {:?}", limited);
             println!("{:?}", results);
-            println!("");
+            println!();
 
             assert_eq!(case.limited, limited);
             assert_eq!(limit, results.limit);
@@ -455,13 +455,13 @@ mod tests {
             limited: bool,
         ) -> RateLimitCase {
             return RateLimitCase {
-                num:         num,
-                now:         now,
-                volume:      volume,
-                remaining:   remaining,
-                reset_after: reset_after,
-                retry_after: retry_after,
-                limited:     limited,
+                num,
+                now,
+                volume,
+                remaining,
+                reset_after,
+                retry_after,
+                limited,
             };
         }
     }
@@ -478,9 +478,9 @@ mod tests {
     impl<'a> TestStore<'a> {
         fn new(store: &'a mut store::MemoryStore) -> TestStore {
             TestStore {
-                clock:        time::empty_tm(),
+                clock: time::empty_tm(),
                 fail_updates: false,
-                store:        store,
+                store,
             }
         }
     }

--- a/src/cell/mod.rs
+++ b/src/cell/mod.rs
@@ -179,7 +179,8 @@ impl<'a, T: 'a + store::Store> RateLimiter<'a, T> {
             // Both of these cases are designed to work around the fact that
             // another limiter could be running in parallel.
             let updated = if tat_val == -1 {
-                self.store.set_if_not_exists_with_ttl(key, new_tat_ns, ttl)?
+                self.store
+                    .set_if_not_exists_with_ttl(key, new_tat_ns, ttl)?
             } else {
                 self.store
                     .compare_and_swap_with_ttl(key, tat_val, new_tat_ns, ttl)?

--- a/src/cell/store.rs
+++ b/src/cell/store.rs
@@ -43,11 +43,11 @@ pub trait Store {
     ) -> Result<bool, CellError>;
 }
 
-/// `MemoryStore` is a simple implementation of Store that persists data in an in-memory
-/// `HashMap`.
+/// `MemoryStore` is a simple implementation of Store that persists data in an
+/// in-memory `HashMap`.
 ///
-/// Note that the implementation is currently not thread-safe and will need a mutex added
-/// if it's ever used for anything serious.
+/// Note that the implementation is currently not thread-safe and will need a
+/// mutex added if it's ever used for anything serious.
 #[derive(Default)]
 pub struct MemoryStore {
     map:     HashMap<String, i64>,
@@ -113,8 +113,8 @@ impl Store for MemoryStore {
     }
 }
 
-/// `InternalRedisStore` is a store implementation that uses Redis module APIs in
-/// that it's designed to run from within a Redis runtime. This allows us to
+/// `InternalRedisStore` is a store implementation that uses Redis module APIs
+/// in that it's designed to run from within a Redis runtime. This allows us to
 /// cut some corners around atomicity because we can safety assume that all
 /// operations will be atomic.
 pub struct InternalRedisStore<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,8 @@ mod redis;
 use cell::store;
 use error::CellError;
 use libc::c_int;
-use redis::Command;
 use redis::raw;
+use redis::Command;
 
 const MODULE_NAME: &str = "redis-cell";
 const MODULE_VERSION: c_int = 1;

--- a/src/redis/mod.rs
+++ b/src/redis/mod.rs
@@ -3,8 +3,10 @@
 //
 // We have to disable a couple Clippy checks here because we'll otherwise have
 // warnings thrown from within macros provided by the `bigflags` package.
-#[cfg_attr(feature = "cargo-clippy",
-           allow(redundant_field_names, suspicious_arithmetic_impl))]
+#[cfg_attr(
+    feature = "cargo-clippy",
+    allow(redundant_field_names, suspicious_arithmetic_impl)
+)]
 pub mod raw;
 
 use error::CellError;

--- a/src/redis/mod.rs
+++ b/src/redis/mod.rs
@@ -5,7 +5,7 @@
 // warnings thrown from within macros provided by the `bigflags` package.
 #[cfg_attr(
     feature = "cargo-clippy",
-    allow(redundant_field_names, suspicious_arithmetic_impl)
+    allow(clippy::redundant_field_names, clippy::suspicious_arithmetic_impl)
 )]
 pub mod raw;
 
@@ -437,9 +437,9 @@ fn from_byte_string(
     length: size_t,
 ) -> Result<String, string::FromUtf8Error> {
     let mut vec_str: Vec<u8> = Vec::with_capacity(length as usize);
-    for j in 0..length {
-        let byte: u8 = unsafe { *byte_str.offset(j as isize) };
-        vec_str.insert(j, byte);
+    for offset in 0..length {
+        let byte: u8 = unsafe { *byte_str.add(offset) };
+        vec_str.insert(offset, byte);
     }
 
     String::from_utf8(vec_str)

--- a/src/redis/raw.rs
+++ b/src/redis/raw.rs
@@ -100,13 +100,7 @@ pub fn create_command(
 ) -> Status {
     unsafe {
         RedisModule_CreateCommand(
-            ctx,
-            name,
-            cmdfunc,
-            strflags,
-            firstkey,
-            lastkey,
-            keystep,
+            ctx, name, cmdfunc, strflags, firstkey, lastkey, keystep,
         )
     }
 }
@@ -207,8 +201,7 @@ extern "C" {
 
     static RedisModule_CloseKey: extern "C" fn(kp: *mut RedisModuleKey);
 
-    static RedisModule_CreateCommand:
-        extern "C" fn(
+    static RedisModule_CreateCommand: extern "C" fn(
         ctx: *mut RedisModuleCtx,
         name: *const u8,
         cmdfunc: Option<RedisModuleCmdFunc>,
@@ -218,9 +211,11 @@ extern "C" {
         keystep: c_int,
     ) -> Status;
 
-    static RedisModule_CreateString:
-        extern "C" fn(ctx: *mut RedisModuleCtx, ptr: *const u8, len: size_t)
-        -> *mut RedisModuleString;
+    static RedisModule_CreateString: extern "C" fn(
+        ctx: *mut RedisModuleCtx,
+        ptr: *const u8,
+        len: size_t,
+    ) -> *mut RedisModuleString;
 
     static RedisModule_FreeString:
         extern "C" fn(ctx: *mut RedisModuleCtx, str: *mut RedisModuleString);
@@ -230,8 +225,7 @@ extern "C" {
     static RedisModule_Log:
         extern "C" fn(ctx: *mut RedisModuleCtx, level: *const u8, fmt: *const u8);
 
-    static RedisModule_OpenKey:
-        extern "C" fn(
+    static RedisModule_OpenKey: extern "C" fn(
         ctx: *mut RedisModuleCtx,
         keyname: *mut RedisModuleString,
         mode: KeyMode,
@@ -252,8 +246,11 @@ extern "C" {
     static RedisModule_SetExpire:
         extern "C" fn(key: *mut RedisModuleKey, expire: c_longlong) -> Status;
 
-    static RedisModule_StringDMA:
-        extern "C" fn(key: *mut RedisModuleKey, len: *mut size_t, mode: KeyMode) -> *const u8;
+    static RedisModule_StringDMA: extern "C" fn(
+        key: *mut RedisModuleKey,
+        len: *mut size_t,
+        mode: KeyMode,
+    ) -> *const u8;
 
     static RedisModule_StringPtrLen:
         extern "C" fn(str: *mut RedisModuleString, len: *mut size_t) -> *const u8;
@@ -261,8 +258,7 @@ extern "C" {
     static RedisModule_StringSet:
         extern "C" fn(key: *mut RedisModuleKey, str: *mut RedisModuleString) -> Status;
 
-    static RedisModule_Call:
-        extern "C" fn(
+    static RedisModule_Call: extern "C" fn(
         ctx: *mut RedisModuleCtx,
         cmdname: *const u8,
         fmt: *const u8,
@@ -284,13 +280,13 @@ pub mod call1 {
 
     #[allow(improper_ctypes)]
     extern "C" {
-        pub static RedisModule_Call:
-            extern "C" fn(
+        pub static RedisModule_Call: extern "C" fn(
             ctx: *mut raw::RedisModuleCtx,
             cmdname: *const u8,
             fmt: *const u8,
             arg0: *mut raw::RedisModuleString,
-        ) -> *mut raw::RedisModuleCallReply;
+        )
+            -> *mut raw::RedisModuleCallReply;
     }
 }
 
@@ -309,14 +305,14 @@ pub mod call2 {
 
     #[allow(improper_ctypes)]
     extern "C" {
-        pub static RedisModule_Call:
-            extern "C" fn(
+        pub static RedisModule_Call: extern "C" fn(
             ctx: *mut raw::RedisModuleCtx,
             cmdname: *const u8,
             fmt: *const u8,
             arg0: *mut raw::RedisModuleString,
             arg1: *mut raw::RedisModuleString,
-        ) -> *mut raw::RedisModuleCallReply;
+        )
+            -> *mut raw::RedisModuleCallReply;
     }
 }
 
@@ -336,14 +332,14 @@ pub mod call3 {
 
     #[allow(improper_ctypes)]
     extern "C" {
-        pub static RedisModule_Call:
-            extern "C" fn(
+        pub static RedisModule_Call: extern "C" fn(
             ctx: *mut raw::RedisModuleCtx,
             cmdname: *const u8,
             fmt: *const u8,
             arg0: *mut raw::RedisModuleString,
             arg1: *mut raw::RedisModuleString,
             arg2: *mut raw::RedisModuleString,
-        ) -> *mut raw::RedisModuleCallReply;
+        )
+            -> *mut raw::RedisModuleCallReply;
     }
 }


### PR DESCRIPTION
The build is currently broken because the method I was using to install
Rustfmt and Clippy is no longer working. Both these programs are now
available as stable components, so change the Travis sequence to take
advantage of that (and fix the build).