### PR TITLE
Switch from crate `gcc` to `cc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ libc = "0.2.0"
 time = "0.1"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0.28"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-extern crate gcc;
+extern crate cc;
 
 fn main() {
     // Build a Redis pseudo-library so that we have symbols that we can link
@@ -7,9 +7,9 @@ fn main() {
     // include/redismodule.h is just vendored in from the Redis project and
     // src/redismodule.c is just a stub that includes it and plays a few other
     // tricks that we need to complete the build.
-    gcc::Build::new()
+    cc::Build::new()
         .file("src/redismodule.c")
         .include("include/")
         .compile("libredismodule.a");
-    // The GCC module emits `rustc-link-lib=static=redismodule` for us.
+    // The cc module emits `rustc-link-lib=static=redismodule` for us.
 }


### PR DESCRIPTION
Apparently the former is now deprecated and the use of `cc` is
recommended now.