### PR TITLE
Remove `RateLimiter`'s lifetime

### DIFF
--- a/src/cell/mod.rs
+++ b/src/cell/mod.rs
@@ -48,8 +48,8 @@ pub struct RateLimitResult {
     pub retry_after: time::Duration,
 }
 
-pub struct RateLimiter<'a, T: 'a + store::Store> {
-    pub store: &'a mut T,
+pub struct RateLimiter<T> {
+    pub store: T,
 
     /// Think of the DVT as our flexibility: how far can you deviate from the
     /// nominal equally spaced schedule? If you like leaky buckets, think about
@@ -64,8 +64,8 @@ pub struct RateLimiter<'a, T: 'a + store::Store> {
     limit: i64,
 }
 
-impl<'a, T: 'a + store::Store> RateLimiter<'a, T> {
-    pub fn new(store: &'a mut T, quota: &RateQuota) -> RateLimiter<'a, T> {
+impl<T: store::Store> RateLimiter<T> {
+    pub fn new(store: T, quota: &RateQuota) -> Self {
         RateLimiter {
             delay_variation_tolerance: time::Duration::nanoseconds(
                 quota.max_rate.period.num_nanoseconds().unwrap() * (quota.max_burst + 1),

--- a/src/cell/store.rs
+++ b/src/cell/store.rs
@@ -43,6 +43,38 @@ pub trait Store {
     ) -> Result<bool, CellError>;
 }
 
+// Implement the `Store` trait for a mutable reference. This is useful so that
+// we don't have to assign a lifetime (`'a`) to `RateLimiter`, thus simplifying
+// our code there by quite a bit.
+impl<'a, T: Store> Store for &'a mut T {
+    fn compare_and_swap_with_ttl(
+        &mut self,
+        key: &str,
+        old: i64,
+        new: i64,
+        ttl: time::Duration,
+    ) -> Result<bool, CellError> {
+        (**self).compare_and_swap_with_ttl(key, old, new, ttl)
+    }
+
+    fn get_with_time(&self, key: &str) -> Result<(i64, time::Tm), CellError> {
+        (**self).get_with_time(key)
+    }
+
+    fn log_debug(&self, message: &str) {
+        (**self).log_debug(message)
+    }
+
+    fn set_if_not_exists_with_ttl(
+        &mut self,
+        key: &str,
+        value: i64,
+        ttl: time::Duration,
+    ) -> Result<bool, CellError> {
+        (**self).set_if_not_exists_with_ttl(key, value, ttl)
+    }
+}
+
 /// `MemoryStore` is a simple implementation of Store that persists data in an
 /// in-memory `HashMap`.
 ///


### PR DESCRIPTION
A nice trick that was suggested in [1] in which we remove the lifetime
(`'a`) from `RateLimiter` and instead give it just a basic `T:
store::Store`, and then enable a reference by implementing the `Store`
trait for `&'a mut T' where `T: Store`.

[1] https://github.com/brandur/redis-cell/issues/23