### PR TITLE
fix redis command key define

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,9 +120,9 @@ pub extern "C" fn RedisModule_OnLoad(
         format!("{}\0", command.name()).as_ptr(),
         Some(Throttle_RedisCommand),
         format!("{}\0", command.str_flags()).as_ptr(),
-        0,
-        0,
-        0,
+        1,
+        1,
+        1,
     ) == raw::Status::Err
     {
         return raw::Status::Err;


### PR DESCRIPTION
Fix command key info when create_command.

The command key info is used in redis cluster. Incorrect command key info will cause cluster can not redirect key to the correct node.