### PR TITLE
Add more docs and a return status

### DIFF
--- a/src/redis/raw.rs
+++ b/src/redis/raw.rs
@@ -133,8 +133,8 @@ pub fn open_key(
     unsafe { RedisModule_OpenKey(ctx, keyname, mode) }
 }
 
-//Calls the same command on the replicas
-pub fn replicate_verbatim(ctx: *mut RedisModuleCtx) {
+// Causes a command to be replicated exactly as invoked on replicas.
+pub fn replicate_verbatim(ctx: *mut RedisModuleCtx) -> Status {
     unsafe { RedisModule_ReplicateVerbatim(ctx) }
 }
 
@@ -243,7 +243,8 @@ extern "C" {
         mode: KeyMode,
     ) -> *mut RedisModuleKey;
 
-    static RedisModule_ReplicateVerbatim: extern "C" fn(ctx: *mut RedisModuleCtx);
+    static RedisModule_ReplicateVerbatim:
+        extern "C" fn(ctx: *mut RedisModuleCtx) -> Status;
 
     static RedisModule_ReplyWithArray:
         extern "C" fn(ctx: *mut RedisModuleCtx, len: c_long) -> Status;


### PR DESCRIPTION
Adds a couple of minor enhancements to follow up #31:

* Adds some documentation around the design decisions of using
  `RedisModule_ReplicateVerbatim`.
* Adds a response status to `RedisModule_ReplicateVerbatim` which we
  handle for general hygiene even if it a non-OK response is never
  expected.