### PR TITLE
Fix various Rustfmt problems in the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,6 @@ install:
   - source ~/.cargo/env || true
 
 before_script:
-  - rustup component add rustfmt
-
   # I'm not clear as to exactly why, but Clippy is occasionally unavailable in
   # certain Nightly builds. This site does a good job of tracking that:
   #
@@ -53,15 +51,18 @@ before_script:
   # For now, I've had to remove it to keep the build green.
   - if [[ -z "$NIGHTLY" ]]; then rustup component add clippy; fi
 
+  # And the same goes for Rustfmt these days unfortunately (I saw some
+  # suggestion that it's borked until version 2 can be released?).
+  - if [[ -z "$NIGHTLY" ]]; then rustup component add rustfmt; fi
+
 script:
   - bash ci/script.sh
 
-  # So close to being on stable, but using a few unstable options in
-  # `rustfmt.toml` (e.g. `wrap_comments` which is *still* not stable!).
-  - if [[ $NIGHTLY == 'true' ]]; then cargo fmt --all -- --check; fi
-
-    # See comment in `before_script`.
+  # See comment in `before_script`.
   - if [[ -z "$NIGHTLY" ]]; then cargo clippy -- -D warnings; fi
+
+  # See comment in `before_script`.
+  - if [[ -z "$NIGHTLY" ]]; then cargo fmt --all -- --check; fi
 
 after_script: set +e
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,9 @@
 max_width = 90
 reorder_imports = true
-struct_field_align_threshold = 20
-unstable_features = true
-wrap_comments = true
+
+# Would love to use these, but they appear to be permanently unstable.
+# Rustfmt's recently stopped working entirely on Nightly which makes them even
+# more impractical to use, so turning them off for now.
+# struct_field_align_threshold = 20
+# unstable_features = true
+# wrap_comments = true

--- a/src/cell/mod.rs
+++ b/src/cell/mod.rs
@@ -50,8 +50,8 @@ impl Rate {
 
 #[derive(Debug, PartialEq)]
 pub struct RateLimitResult {
-    pub limit:       i64,
-    pub remaining:   i64,
+    pub limit: i64,
+    pub remaining: i64,
     pub reset_after: time::Duration,
     pub retry_after: time::Duration,
 }
@@ -100,8 +100,8 @@ impl<T: store::Store> RateLimiter<T> {
         quantity: i64,
     ) -> Result<(bool, RateLimitResult), CellError> {
         let mut rlc = RateLimitResult {
-            limit:       self.limit,
-            remaining:   0,
+            limit: self.limit,
+            remaining: 0,
             retry_after: time::Duration::seconds(-1),
             reset_after: time::Duration::seconds(-1),
         };
@@ -270,13 +270,13 @@ impl<T: store::Store> RateLimiter<T> {
 #[derive(Debug, PartialEq)]
 pub struct RateQuota {
     pub max_burst: i64,
-    pub max_rate:  Rate,
+    pub max_rate: Rate,
 }
 
 fn from_nanoseconds(x: i64) -> time::Tm {
     let ns = (10 as i64).pow(9);
     time::at(time::Timespec {
-        sec:  x / ns,
+        sec: x / ns,
         nsec: (x % ns) as i32,
     })
 }
@@ -447,7 +447,7 @@ mod tests {
     fn it_does_not_support_zero_rates() {
         let quota = RateQuota {
             max_burst: 10,
-            max_rate:  Rate::per_period(0, time::Duration::seconds(0)),
+            max_rate: Rate::per_period(0, time::Duration::seconds(0)),
         };
         let mut memory_store = store::MemoryStore::new_verbose();
 
@@ -465,7 +465,7 @@ mod tests {
     fn it_handles_rate_limit_update_failures() {
         let quota = RateQuota {
             max_burst: 1,
-            max_rate:  Rate::per_second(1),
+            max_rate: Rate::per_second(1),
         };
         let mut memory_store = store::MemoryStore::new_verbose();
         let mut test_store = TestStore::new(&mut memory_store);
@@ -483,13 +483,13 @@ mod tests {
 
     #[derive(Debug, PartialEq)]
     struct RateLimitCase {
-        num:         i64,
-        now:         time::Tm,
-        volume:      i64,
-        remaining:   i64,
+        num: i64,
+        now: time::Tm,
+        volume: i64,
+        remaining: i64,
         reset_after: time::Duration,
         retry_after: time::Duration,
-        limited:     bool,
+        limited: bool,
     }
 
     impl RateLimitCase {
@@ -518,9 +518,9 @@ mod tests {
     /// us to tweak certain behavior, like for example setting the effective
     /// system clock.
     struct TestStore<'a> {
-        clock:        time::Tm,
+        clock: time::Tm,
         fail_updates: bool,
-        store:        &'a mut store::MemoryStore,
+        store: &'a mut store::MemoryStore,
     }
 
     impl<'a> TestStore<'a> {

--- a/src/cell/store.rs
+++ b/src/cell/store.rs
@@ -82,7 +82,7 @@ impl<'a, T: Store> Store for &'a mut T {
 /// mutex added if it's ever used for anything serious.
 #[derive(Default)]
 pub struct MemoryStore {
-    map:     HashMap<String, i64>,
+    map: HashMap<String, i64>,
     verbose: bool,
 }
 
@@ -93,7 +93,7 @@ impl MemoryStore {
 
     pub fn new_verbose() -> MemoryStore {
         MemoryStore {
-            map:     HashMap::new(),
+            map: HashMap::new(),
             verbose: true,
         }
     }

--- a/src/redis/mod.rs
+++ b/src/redis/mod.rs
@@ -262,9 +262,9 @@ pub enum KeyMode {
 /// operation through the use of the Drop trait.
 #[derive(Debug)]
 pub struct RedisKey {
-    ctx:       *mut raw::RedisModuleCtx,
+    ctx: *mut raw::RedisModuleCtx,
     key_inner: *mut raw::RedisModuleKey,
-    key_str:   RedisString,
+    key_str: RedisString,
 }
 
 impl RedisKey {
@@ -304,7 +304,7 @@ impl Drop for RedisKey {
 /// `RedisKeyWritable` is an abstraction over a Redis key that allows read and
 /// write operations.
 pub struct RedisKeyWritable {
-    ctx:       *mut raw::RedisModuleCtx,
+    ctx: *mut raw::RedisModuleCtx,
     key_inner: *mut raw::RedisModuleKey,
 
     // The Redis string
@@ -382,7 +382,7 @@ impl Drop for RedisKeyWritable {
 /// fault-free operation through the use of the Drop trait.
 #[derive(Debug)]
 pub struct RedisString {
-    ctx:       *mut raw::RedisModuleCtx,
+    ctx: *mut raw::RedisModuleCtx,
     str_inner: *mut raw::RedisModuleString,
 }
 


### PR DESCRIPTION
The unstable features I was using are still unstable (they appear to be
permanently so), and the situation's gotten worse in that Rustfmt seems
to not really be available in nightly builds anymore, which was the only
way that unstable features could be used.

For now, stop using those unstable features and stop running Rustfmt in
nightly, preferring only the stable channel instead.