### PR TITLE
Disable FreeBSD target in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
     - env: TARGET=x86_64-unknown-linux-gnu
     - env: TARGET=x86_64-apple-darwin
       os: osx
-    - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
 
     # Testing other channels
     - env:


### PR DESCRIPTION
Apparently the Rust Cross project doesn't support FreeBSD anymore:

https://github.com/rust-embedded/cross/issues/274
https://github.com/rust-embedded/cross/issues/306