### PR TITLE
Replicate `CL.THROTTLE` invocations to replicas/AOF

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,10 @@ impl Command for ThrottleCommand {
         r.reply_integer(rate_limit_result.retry_after.num_seconds())?;
         r.reply_integer(rate_limit_result.reset_after.num_seconds())?;
 
+        // Tell Redis that it's okay to replicate the command with the same
+        // parameters out to replicas.
+        r.replicate_verbatim()?;
+
         Ok(())
     }
 

--- a/src/redis/mod.rs
+++ b/src/redis/mod.rs
@@ -219,6 +219,16 @@ impl Redis {
         RedisKeyWritable::open(self.ctx, key)
     }
 
+    /// Tells Redis to replicate the command to replicas an AOF as is.
+    pub fn replicate_verbatim(&self) -> Result<(), CellError> {
+        // Handle a possible error for hygiene, but the documentation specifically
+        // states that the function always returns `REDISMODULE_OK`.
+        handle_status(
+            raw::replicate_verbatim(self.ctx),
+            "Could not replicate verbatim",
+        )
+    }
+
     /// Tells Redis that we're about to reply with an (Redis) array.
     ///
     /// Used by invoking once with the expected length and then calling any


### PR DESCRIPTION
Here we add an invocation to `RedisModule_ReplicateVerbatim` so that
invoking `CL.THROTTLE` will replicate out to replicas/AOF.

This _also_ has the side effect of incrementing a dirty counter within
the Redis server so that RDB snapshots work properly, thus fixing #52.