### PR TITLE
chore: fix warnings + remove --write-mode since it's no longer supported

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@
 all: test fmt lint
 
 fmt:
-	cargo +nightly fmt -- --write-mode=diff
-
+	cargo +nightly fmt --
 lint:
 	cargo +nightly clippy -- -D warnings
 

--- a/src/cell/mod.rs
+++ b/src/cell/mod.rs
@@ -274,7 +274,7 @@ pub struct RateQuota {
 }
 
 fn from_nanoseconds(x: i64) -> time::Tm {
-    let ns = (10 as i64).pow(9);
+    let ns = 10_i64.pow(9);
     time::at(time::Timespec {
         sec: x / ns,
         nsec: (x % ns) as i32,
@@ -283,7 +283,7 @@ fn from_nanoseconds(x: i64) -> time::Tm {
 
 fn nanoseconds(x: time::Tm) -> i64 {
     let ts = x.to_timespec();
-    ts.sec * (10 as i64).pow(9) + i64::from(ts.nsec)
+    ts.sec * 10_i64.pow(9) + i64::from(ts.nsec)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ pub extern "C" fn Throttle_RedisCommand(
     argv: *mut *mut raw::RedisModuleString,
     argc: c_int,
 ) -> raw::Status {
-    Command::harness(&ThrottleCommand {}, ctx, argv, argc)
+    <dyn Command>::harness(&ThrottleCommand {}, ctx, argv, argc)
 }
 
 #[allow(non_snake_case)]


### PR DESCRIPTION
- since `--write-mode` is no longer supported, remove it from `Makefile->fmt`
- fix unnecessary cast

Signed-off-by: Tuan Anh Tran <me@tuananh.org>