### PR TITLE
Fix build errors after long pause

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust:
-          - 1.38.0
+        rust_toolchain:
           - stable
+          - nightly
     timeout-minutes: 5
 
     steps:
@@ -50,7 +50,7 @@ jobs:
           components: clippy, rustfmt
           override: true
           profile: minimal
-          toolchain: ${{ matrix.rust }}
+          toolchain: ${{ matrix.rust_toolchain }}
 
       - name: "Cargo: Check"
         uses: actions-rs/cargo@v1
@@ -78,58 +78,6 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
-
-  # Very, very similar to the `build` job above, but defined separately because
-  # individual components like Clippy and Rustfmt are often not available in
-  # nightly builds, and the build will fail if we try to add them. Therefore,
-  # this is the exact same thing minus the Clippy/Rustfmt checks.
-  build_nightly:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v2
-
-      - name: "Cache: Cargo registry"
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: "Cache: Cargo index"
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: "Cache: Cargo build"
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: "Install: Rust toolchain"
-        uses: actions-rs/toolchain@v1
-        with:
-          override: true
-          profile: minimal
-          toolchain: nightly
-
-      - name: "Cargo: Check"
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-
-      - name: "Cargo: Build"
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-
-      - name: "Cargo: Test"
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
 
   #
   # RELEASE JOBS
@@ -181,7 +129,6 @@ jobs:
     if: contains(github.ref, 'tags/v')
     needs:
       - build
-      - build_nightly
       - release_create
     runs-on: ubuntu-latest
     strategy:
@@ -279,7 +226,6 @@ jobs:
     if: contains(github.ref, 'tags/v')
     needs:
       - build
-      - build_nightly
       - release_create
     runs-on: macos-latest
     strategy:

--- a/src/cell/mod.rs
+++ b/src/cell/mod.rs
@@ -8,7 +8,7 @@ use error::CellError;
 // operations before returning an error.
 const MAX_CAS_ATTEMPTS: i64 = 5;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Rate {
     pub period: time::Duration,
 }
@@ -48,7 +48,7 @@ impl Rate {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct RateLimitResult {
     pub limit: i64,
     pub remaining: i64,
@@ -267,7 +267,7 @@ impl<T: store::Store> RateLimiter<T> {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct RateQuota {
     pub max_burst: i64,
     pub max_rate: Rate,
@@ -481,7 +481,7 @@ mod tests {
         );
     }
 
-    #[derive(Debug, PartialEq)]
+    #[derive(Debug, Eq, PartialEq)]
     struct RateLimitCase {
         num: i64,
         now: time::Tm,

--- a/src/error.rs
+++ b/src/error.rs
@@ -66,13 +66,13 @@ impl GenericError {
     }
 }
 
-impl<'a> fmt::Display for GenericError {
+impl fmt::Display for GenericError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Store error: {}", self.message)
     }
 }
 
-impl<'a> error::Error for GenericError {
+impl error::Error for GenericError {
     fn description(&self) -> &str {
         self.message.as_str()
     }

--- a/src/redis/raw.rs
+++ b/src/redis/raw.rs
@@ -17,7 +17,7 @@ bitflags! {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum ReplyType {
     Unknown = -1,
     String = 0,
@@ -27,7 +27,7 @@ pub enum ReplyType {
     Nil = 4,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(C)]
 pub enum Status {
     Ok = 0,


### PR DESCRIPTION
Fix build errors that have crept in after a long winter without changes.

Also remove the special `build_nightly` job. Hopefully Rust is a bit
more stable now and this is no longer necessary.