### PR TITLE
Publish to ARM64 for Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
     strategy:
       matrix:
         target:
+          - aarch64-unknown-linux-gnu
           - armv7-unknown-linux-gnueabihf
           - x86_64-unknown-linux-gnu
     timeout-minutes: 5


### PR DESCRIPTION
Publish releases for the `aarch64-unknown-linux-gnu` target.