### PR TITLE
Update CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every month
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,22 +23,22 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Cache: Cargo registry"
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
       - name: "Cache: Cargo index"
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
       - name: "Cache: Cargo build"
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
@@ -139,22 +139,22 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Cache: Cargo registry"
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
       - name: "Cache: Cargo index"
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
       - name: "Cache: Cargo build"
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
@@ -175,7 +175,7 @@ jobs:
           use-cross: true
 
       - name: "Download release URL file"
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: release_url
 
@@ -235,22 +235,22 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "Cache: Cargo registry"
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
       - name: "Cache: Cargo index"
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
       - name: "Cache: Cargo build"
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
@@ -271,7 +271,7 @@ jobs:
           use-cross: true
 
       - name: "Download release URL file"
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: release_url
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,10 +182,10 @@ jobs:
       - name: "Get release info"
         id: get_release_info
         run: |
-          echo ::set-output name=file_name::${REPOSITORY_NAME##*/}-${TAG_REF_NAME##*/}-${{ matrix.target }}.tar.gz # RepositoryName-v1.0.0-arch.tar.gz
+          echo "name=file_name::${REPOSITORY_NAME##*/}-${TAG_REF_NAME##*/}-${{ matrix.target }}.tar.gz" >> "$GITHUB_OUTPUT" # RepositoryName-v1.0.0-arch.tar.gz
 
           value=`cat release_url/release_url.txt`
-          echo ::set-output name=upload_url::$value
+          echo "name=upload_url::$value" >> "$GITHUB_OUTPUT"
         env:
           REPOSITORY_NAME: ${{ github.repository }}
           TAG_REF_NAME: ${{ github.ref }}
@@ -278,10 +278,10 @@ jobs:
       - name: "Get release info"
         id: get_release_info
         run: |
-          echo ::set-output name=file_name::${REPOSITORY_NAME##*/}-${TAG_REF_NAME##*/}-${{ matrix.target }}.tar.gz # RepositoryName-v1.0.0-arch.tar.gz
+          echo "name=file_name::${REPOSITORY_NAME##*/}-${TAG_REF_NAME##*/}-${{ matrix.target }}.tar.gz" >> "$GITHUB_OUTPUT" # RepositoryName-v1.0.0-arch.tar.gz
 
           value=`cat release_url/release_url.txt`
-          echo ::set-output name=upload_url::$value
+          echo "name=upload_url::$value" >> "$GITHUB_OUTPUT"
         env:
           REPOSITORY_NAME: ${{ github.repository }}
           TAG_REF_NAME: ${{ github.ref }}


### PR DESCRIPTION
Resolves #63

- [x] Update github actions
- [x] Add dependabot to keep actions up to date
- [x] Fix `set-output` deprecation
- [ ] Replace deprecated rust toolchain action(s)
- [ ] Replace deprecated `upload-release-asset` action