### PR TITLE
Upgrade version of dependencies + fix `time` breakages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ repository = "https://github.com/brandur/redis-cell"
 crate-type = ["dylib"]
 
 [dependencies]
-bitflags = "1.0"
-libc = "0.2.0"
-time = "0.1"
+bitflags = "2.6"
+libc = "0.2"
+time = { version = "0.3", features = ["formatting"] }
 
 [build-dependencies]
 cc = "1.0.28"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,12 +66,12 @@ impl Command for ThrottleCommand {
         // If either time had a partial component, but it up to the next full
         // second because otherwise a fast-paced caller could try again too
         // early.
-        let mut retry_after = rate_limit_result.retry_after.num_seconds();
-        if rate_limit_result.retry_after.num_milliseconds() > 0 {
+        let mut retry_after = rate_limit_result.retry_after.as_seconds_f64() as i64;
+        if rate_limit_result.retry_after.subsec_milliseconds() > 0 {
             retry_after += 1
         }
-        let mut reset_after = rate_limit_result.reset_after.num_seconds();
-        if rate_limit_result.reset_after.num_milliseconds() > 0 {
+        let mut reset_after = rate_limit_result.reset_after.as_seconds_f64() as i64;
+        if rate_limit_result.reset_after.subsec_milliseconds() > 0 {
             reset_after += 1
         }
 

--- a/src/redis/mod.rs
+++ b/src/redis/mod.rs
@@ -344,7 +344,7 @@ impl RedisKeyWritable {
     }
 
     pub fn set_expire(&self, expire: time::Duration) -> Result<(), CellError> {
-        match raw::set_expire(self.key_inner, expire.num_milliseconds()) {
+        match raw::set_expire(self.key_inner, expire.whole_milliseconds() as i64) {
             raw::Status::Ok => Ok(()),
 
             // Error may occur if the key wasn't open for writing or is an


### PR DESCRIPTION
To keep things somewhat current, upgrade all dependencies to latest
versions.

The hardest by far is `time`, which has broken its entire API surface
area, _again_. We make some fairly substantial code changes to
accommodate that.

I also changed the store API to use `u64`s instead of `i64`s since
they're working with nanoseconds. I realize in retrospect that this
change might not be needed since Redis works with a signed integer type,
but it improves the interface slightly in that a missing value is
returned as a `None` instead of `-1`, which is more Rust-like.