### PR TITLE
Modernize cache step in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,25 +23,16 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: "Cache: Cargo registry"
-        uses: actions/cache@v1
+      - name: Cache
+        uses: actions/cache@v4
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: "Cache: Cargo index"
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: "Cache: Cargo build"
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: "Install: Rust toolchain"
         uses: actions-rs/toolchain@v1
@@ -139,25 +130,16 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: "Cache: Cargo registry"
-        uses: actions/cache@v1
+      - name: Cache
+        uses: actions/cache@v4
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: "Cache: Cargo index"
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: "Cache: Cargo build"
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: "Install: Rust toolchain"
         uses: actions-rs/toolchain@v1
@@ -235,25 +217,16 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: "Cache: Cargo registry"
-        uses: actions/cache@v1
+      - name: Cache
+        uses: actions/cache@v4
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: "Cache: Cargo index"
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: "Cache: Cargo build"
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: "Install: Rust toolchain"
         uses: actions-rs/toolchain@v1

--- a/src/cell/store.rs
+++ b/src/cell/store.rs
@@ -131,7 +131,7 @@ impl Store for MemoryStore {
 
     fn log_debug(&self, message: &str) {
         if self.verbose {
-            println!("memory_store: {}", message);
+            println!("memory_store: {message}");
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,9 +31,9 @@ impl fmt::Display for CellError {
         match *self {
             // All underlying errors already impl `Display`, so we defer to
             // their implementations.
-            CellError::Generic(ref err) => write!(f, "{}", err),
-            CellError::FromUtf8(ref err) => write!(f, "{}", err),
-            CellError::ParseInt(ref err) => write!(f, "{}", err),
+            CellError::Generic(ref err) => write!(f, "{err}"),
+            CellError::FromUtf8(ref err) => write!(f, "{err}"),
+            CellError::ParseInt(ref err) => write!(f, "{err}"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ pub extern "C" fn RedisModule_OnLoad(
 ) -> raw::Status {
     if raw::init(
         ctx,
-        format!("{}\0", MODULE_NAME).as_ptr(),
+        format!("{MODULE_NAME}\0").as_ptr(),
         MODULE_VERSION,
         raw::REDISMODULE_APIVER_1,
     ) == raw::Status::Err

--- a/src/redis/mod.rs
+++ b/src/redis/mod.rs
@@ -58,7 +58,7 @@ impl dyn Command {
         match command.run(r, str_args.as_slice()) {
             Ok(_) => raw::Status::Ok,
             Err(e) => {
-                raw::reply_with_error(ctx, format!("Cell error: {}\0", e).as_ptr());
+                raw::reply_with_error(ctx, format!("Cell error: {e}\0").as_ptr());
                 raw::Status::Err
             }
         }
@@ -107,22 +107,22 @@ impl Redis {
                 // it's left unchanged.
                 raw::call1::call(
                     self.ctx,
-                    format!("{}\0", command).as_ptr(),
-                    format!("{}\0", format).as_ptr(),
+                    format!("{command}\0").as_ptr(),
+                    format!("{format}\0").as_ptr(),
                     terminated_args[0].str_inner,
                 )
             }
             2 => raw::call2::call(
                 self.ctx,
-                format!("{}\0", command).as_ptr(),
-                format!("{}\0", format).as_ptr(),
+                format!("{command}\0").as_ptr(),
+                format!("{format}\0").as_ptr(),
                 terminated_args[0].str_inner,
                 terminated_args[1].str_inner,
             ),
             3 => raw::call3::call(
                 self.ctx,
-                format!("{}\0", command).as_ptr(),
-                format!("{}\0", format).as_ptr(),
+                format!("{command}\0").as_ptr(),
+                format!("{format}\0").as_ptr(),
                 terminated_args[0].str_inner,
                 terminated_args[1].str_inner,
                 terminated_args[2].str_inner,
@@ -189,8 +189,8 @@ impl Redis {
     pub fn log(&self, level: LogLevel, message: &str) {
         raw::log(
             self.ctx,
-            format!("{:?}\0", level).to_lowercase().as_ptr(),
-            format!("{}\0", message).as_ptr(),
+            format!("{level:?}\0").to_lowercase().as_ptr(),
+            format!("{message}\0").as_ptr(),
         );
     }
 
@@ -384,7 +384,7 @@ pub struct RedisString {
 
 impl RedisString {
     fn create(ctx: *mut raw::RedisModuleCtx, s: &str) -> RedisString {
-        let str_inner = raw::create_string(ctx, format!("{}\0", s).as_ptr(), s.len());
+        let str_inner = raw::create_string(ctx, format!("{s}\0").as_ptr(), s.len());
         RedisString { ctx, str_inner }
     }
 }


### PR DESCRIPTION
Modernize cache step in GitHub Actions as currently the use of v1 is
failing all builds [1].

Also put variables directly in `format!` directives, which apparently is
a thing now, and which Clippy will complain about if not done.

[1] https://github.com/brandur/redis-cell/actions/runs/15657611871/job/44110741744