### PR TITLE
Upgrade to Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.4.0"
 authors = ["Brandur <brandur@mutelight.org>"]
 build = "build.rs"
 description = "A Redis module that provides rate limiting in Redis as a single command."
+edition = '2024'
 license = "MIT"
 repository = "https://github.com/brandur/redis-cell"
 

--- a/src/cell/mod.rs
+++ b/src/cell/mod.rs
@@ -2,7 +2,7 @@ extern crate time;
 
 pub mod store;
 
-use error::CellError;
+use crate::error::CellError;
 
 // Maximum number of times to retry set_if_not_exists/compare_and_swap
 // operations before returning an error.
@@ -299,8 +299,8 @@ fn nanoseconds(x: time::OffsetDateTime) -> u64 {
 mod tests {
     extern crate time;
 
-    use cell::*;
-    use error::CellError;
+    use crate::cell::*;
+    use crate::error::CellError;
 
     #[test]
     fn it_creates_rates_from_days() {

--- a/src/cell/store.rs
+++ b/src/cell/store.rs
@@ -1,7 +1,7 @@
 extern crate time;
 
-use error::CellError;
-use redis;
+use crate::error::CellError;
+use crate::redis;
 use std::collections::HashMap;
 
 /// Store exposes the atomic data store operations that the GCRA rate limiter
@@ -237,7 +237,7 @@ impl Store for InternalRedisStore<'_> {
 mod tests {
     extern crate time;
 
-    use cell::store::*;
+    use crate::cell::store::*;
 
     #[test]
     fn it_performs_compare_and_swap_with_ttl() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,11 @@ pub mod cell;
 pub mod error;
 mod redis;
 
-use cell::store;
-use error::CellError;
+use crate::cell::store;
+use crate::error::CellError;
+use crate::redis::Command;
+use crate::redis::raw;
 use libc::c_int;
-use redis::raw;
-use redis::Command;
 
 const MODULE_NAME: &str = "redis-cell";
 const MODULE_VERSION: c_int = 1;
@@ -103,7 +103,7 @@ impl Command for ThrottleCommand {
 
 #[allow(non_snake_case)]
 #[allow(unused_variables)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn Throttle_RedisCommand(
     ctx: *mut raw::RedisModuleCtx,
     argv: *mut *mut raw::RedisModuleString,
@@ -114,7 +114,7 @@ pub extern "C" fn Throttle_RedisCommand(
 
 #[allow(non_snake_case)]
 #[allow(unused_variables)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn RedisModule_OnLoad(
     ctx: *mut raw::RedisModuleCtx,
     argv: *mut *mut raw::RedisModuleString,

--- a/src/redis/mod.rs
+++ b/src/redis/mod.rs
@@ -2,7 +2,7 @@
 // instead.
 pub mod raw;
 
-use error::CellError;
+use crate::error::CellError;
 use libc::{c_int, c_long, c_longlong, size_t};
 use std::ptr;
 use std::string;

--- a/src/redis/raw.rs
+++ b/src/redis/raw.rs
@@ -186,7 +186,7 @@ pub fn string_set(key: *mut RedisModuleKey, str: *mut RedisModuleString) -> Stat
 // during build and link against that. See build.rs for details.
 #[allow(improper_ctypes)]
 #[link(name = "redismodule", kind = "static")]
-extern "C" {
+unsafe extern "C" {
     pub fn Export_RedisModule_Init(
         ctx: *mut RedisModuleCtx,
         modulename: *const u8,
@@ -276,7 +276,7 @@ extern "C" {
 }
 
 pub mod call1 {
-    use redis::raw;
+    use crate::redis::raw;
 
     pub fn call(
         ctx: *mut raw::RedisModuleCtx,
@@ -288,7 +288,7 @@ pub mod call1 {
     }
 
     #[allow(improper_ctypes)]
-    extern "C" {
+    unsafe extern "C" {
         pub static RedisModule_Call: extern "C" fn(
             ctx: *mut raw::RedisModuleCtx,
             cmdname: *const u8,
@@ -300,7 +300,7 @@ pub mod call1 {
 }
 
 pub mod call2 {
-    use redis::raw;
+    use crate::redis::raw;
 
     pub fn call(
         ctx: *mut raw::RedisModuleCtx,
@@ -313,7 +313,7 @@ pub mod call2 {
     }
 
     #[allow(improper_ctypes)]
-    extern "C" {
+    unsafe extern "C" {
         pub static RedisModule_Call: extern "C" fn(
             ctx: *mut raw::RedisModuleCtx,
             cmdname: *const u8,
@@ -326,7 +326,7 @@ pub mod call2 {
 }
 
 pub mod call3 {
-    use redis::raw;
+    use crate::redis::raw;
 
     pub fn call(
         ctx: *mut raw::RedisModuleCtx,
@@ -340,7 +340,7 @@ pub mod call3 {
     }
 
     #[allow(improper_ctypes)]
-    extern "C" {
+    unsafe extern "C" {
         pub static RedisModule_Call: extern "C" fn(
             ctx: *mut raw::RedisModuleCtx,
             cmdname: *const u8,


### PR DESCRIPTION
Upgrade to Rust 2024 and set `edition` in `Cargo.toml` (this code
preexists editions so it wasn't set at all before).

Mostly done with:

    cargo fix --edition

With a few manual fixes to add more `unsafe` symbols in places like
`extern "C"` blocks.